### PR TITLE
Update installation_der_software.md

### DIFF
--- a/de/getting_started/installation_der_software.md
+++ b/de/getting_started/installation_der_software.md
@@ -28,7 +28,7 @@ Dazu sind folgende Schritte nötig:
 7. Windows wird die Treiberinstallation vervollständigen und der Arduino-Uno sollte funktionieren.
 
 ## Arduino Bibliotheken installieren
-Um die Sensoren und die Netzwerkkarte nutzen zu können, müssen noch ein paar Bibliotheken installiert werden. Ein zip-Archiv mit allen benötigten Bibliotheken findet ihr [hier](https://github.com/sensebox/resources/raw/master/libraries/senseBox_Libraries.zip).
+Um die Sensoren und die Netzwerkkarte nutzen zu können, müssen noch ein paar Bibliotheken installiert werden. Ein zip-Archiv mit allen benötigten Bibliotheken findet ihr [hier](https://github.com/sensebox/senseBox_library/archive/master.zip).
 
 Ladet das zip-Archiv herunter und integriert nun die beiden Ordner „examples“ und „libraries“ aus dem Archiv in euren Arduino Ordner.
 Wenn ihr gefragt werdet ob bestehende Dateien ersetzt werden sollen, folgt den Anweisungen unten auf der Seite.

--- a/de/getting_started/installation_der_software.md
+++ b/de/getting_started/installation_der_software.md
@@ -30,11 +30,4 @@ Dazu sind folgende Schritte nötig:
 ## Arduino Bibliotheken installieren
 Um die Sensoren und die Netzwerkkarte nutzen zu können, müssen noch ein paar Bibliotheken installiert werden. Ein zip-Archiv mit allen benötigten Bibliotheken findet ihr [hier](https://github.com/sensebox/senseBox_library/archive/master.zip).
 
-Ladet das zip-Archiv herunter und integriert nun die beiden Ordner „examples“ und „libraries“ aus dem Archiv in euren Arduino Ordner.
-Wenn ihr gefragt werdet ob bestehende Dateien ersetzt werden sollen, folgt den Anweisungen unten auf der Seite.
-
-<img src="https://raw.githubusercontent.com/sensebox/resources/master/images/home/06_copy.png" align="center" width="400"/>
-
-Setzt nun, wie unten dargestellt, im ersten Dialogfeld den Haken unten und bestätigt mit „Ja“. Daraufhin öffnet sich ein neues Fenster, in dem ihr wieder den Haken setzt, und „Kopieren und ersetzen“ auswählt.
-
-<img src="https://raw.githubusercontent.com/sensebox/resources/master/images/home/07_replace.png" align="center" width="400"/>
+Ladet das zip-Archiv herunter und öffnet die Arduino-Software. In der Arduino-Software muss dann über die Menüfolge Sketch --> Bibliothek einbinden --> .ZIP-Bibliothek einbinden… die gerade heruntergeladene Bibliothek in die Arduino-Bibliothekensammlung aufgenommen werden.


### PR DESCRIPTION
Link war veraltet, sodass die Lib nicht mit der aktuellen Arduino-Software kompatibel war. Eventuell würde es sich anbieten, eine mit Screenshots bebilderte Anleitung zur Installation der Lib in das Buch / die Bücher mit aufzunehmen.